### PR TITLE
Fix procedural tower level generation

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -14,8 +14,26 @@
   const params = new URLSearchParams(location.search);
   let currentLevel = params.has('load') || params.has('continue') ? save.level : 1;
 
+  function freshSeed(){
+    return Math.floor(Math.random() * 0xffffffff);
+  }
+
+  let levelSeed;
+  if(params.has('load') || params.has('continue')){
+    levelSeed = typeof save.currentSeed === 'number' ? save.currentSeed : freshSeed();
+    if(save.currentSeed !== levelSeed){
+      save.currentSeed = levelSeed;
+      Storage.write(save);
+    }
+  }else{
+    levelSeed = freshSeed();
+    save.level = currentLevel;
+    save.currentSeed = levelSeed;
+    Storage.write(save);
+  }
+
   // Create level layout
-  let level = LevelGen.generateLevel(currentLevel, W, H);
+  let level = LevelGen.generateLevel(currentLevel, W, H, levelSeed);
   level.width = W; level.height = H;
 
   // Player
@@ -76,6 +94,8 @@
     currentLevel += 1;
     save.level = currentLevel;
     save.bestLevel = Math.max(save.bestLevel, currentLevel);
+    levelSeed = freshSeed();
+    save.currentSeed = levelSeed;
     Storage.write(save);
 
     // Every 5 floors go to shop
@@ -84,7 +104,7 @@
       return;
     }
     // Otherwise regenerate level and reset player
-    level = LevelGen.generateLevel(currentLevel, W, H);
+    level = LevelGen.generateLevel(currentLevel, W, H, levelSeed);
     level.width = W; level.height = H;
     player.pos.x = 80; player.pos.y = H - 120;
     player.vel.x = 0; player.vel.y = 0;
@@ -97,8 +117,10 @@
     const blockStart = Math.max(1, currentLevel - ((currentLevel-1)%5));
     currentLevel = blockStart;
     save.level = currentLevel;
+    levelSeed = freshSeed();
+    save.currentSeed = levelSeed;
     Storage.write(save);
-    level = LevelGen.generateLevel(currentLevel, W, H);
+    level = LevelGen.generateLevel(currentLevel, W, H, levelSeed);
     level.width = W; level.height = H;
     player.pos.x = 80; player.pos.y = H - 120;
     player.vel.x = 0; player.vel.y = 0;

--- a/js/level.js
+++ b/js/level.js
@@ -7,37 +7,89 @@
     return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
   }
 
+  function createRng(seed){
+    let a = seed >>> 0;
+    if(a === 0) a = 0x9e3779b1;
+    return function(){
+      a += 0x6d2b79f5;
+      let t = Math.imul(a ^ a >>> 15, 1 | a);
+      t ^= t + Math.imul(t ^ t >>> 7, 61 | t);
+      return ((t ^ t >>> 14) >>> 0) / 4294967296;
+    };
+  }
+
+  function clamp(v, min, max){
+    return Math.max(min, Math.min(max, v));
+  }
+
   // Create a random set of platforms that "staircase" upward.
-  function generateLevel(floor, width, height){
-    const rng = (seed => () => (seed = (seed*9301+49297)%233280)/233280)(floor*1337);
+  function generateLevel(floor, width, height, seed){
+    const baseSeed = typeof seed === 'number' ? Math.floor(seed) : Math.floor(Math.random()*0xffffffff);
+    const rng = createRng(baseSeed ^ (floor * 0x9e3779b1));
     const platforms = [];
 
     const groundH = 24;
-    // Start platform near bottom
-    platforms.push({x: 40, y: height-64, w: 200, h: 16});
+    const floorY = height - groundH;
 
-    // A handful of rising platforms
-    const count = 8 + Math.min(10, Math.floor(floor/2));
-    let y = height - 120;
-    for(let i=0;i<count;i++){
-      const w = 120 + Math.floor(rng()*180);
-      const x = 80 + Math.floor(rng()*(width - w - 160));
-      platforms.push({x, y, w, h: 14});
-      y -= 40 + Math.floor(rng()*40);
+    // Start platform near bottom providing safe landing
+    const startPlatform = {x: 40, y: floorY - 40, w: 220, h: 16};
+    platforms.push(startPlatform);
+
+    let previous = startPlatform;
+    let y = previous.y;
+    const climbCount = 6 + Math.min(6, Math.floor(floor/2));
+
+    for(let i=0;i<climbCount;i++){
+      const w = 140 + Math.floor(rng()*140);
+      const riseMin = 42;
+      const riseMax = 76 + Math.min(30, floor*3);
+      y = Math.max(90, y - (riseMin + rng()*(riseMax - riseMin)));
+
+      const progress = climbCount <= 1 ? 1 : i / (climbCount - 1);
+      const drift = (rng() - 0.25) * 160;
+      let desired = previous.x + previous.w * 0.6 + drift + progress * 150;
+      const minX = clamp(previous.x - 120 + progress * 60, 20, width - w - 20);
+      const maxX = clamp(previous.x + previous.w - 40 + 160 + progress * 160, 20, width - w - 20);
+      const x = clamp(desired, minX, maxX);
+
+      const platform = {x: Math.round(x), y: Math.round(y), w, h: 14};
+      platform.x = clamp(platform.x, 20, width - platform.w - 20);
+      platforms.push(platform);
+      previous = platform;
     }
 
-    // Exit door (reach it to finish floor)
-    const exit = {x: width-100, y: Math.max(60, y - 40), w: 40, h: 60};
+    // Ensure we have a landing close to the exit on the right side
+    if(previous.x + previous.w < width - 140){
+      const bridge = {
+        x: Math.round(clamp(previous.x + previous.w - 80, 40, width - 240)),
+        y: Math.round(Math.max(80, previous.y - (30 + rng()*30))),
+        w: 240,
+        h: 14
+      };
+      platforms.push(bridge);
+      previous = bridge;
+    }
 
-    // A few hazards (spikes)
+    // Exit door aligns with the final platform
+    const exit = {
+      x: Math.round(clamp(previous.x + previous.w - 50, previous.x + 20, width - 60)),
+      y: Math.round(previous.y - 60),
+      w: 40,
+      h: 60
+    };
+
+    // A few hazards (spikes) placed only on intermediate platforms
     const hazards = [];
-    const hazardCount = Math.min(6, Math.floor(floor/3)+2);
+    const hazardPool = platforms.slice(1, -1).filter(p => p.w > 80);
+    const hazardCount = Math.min(hazardPool.length, 2 + Math.floor((floor + 1)/3));
     for(let i=0;i<hazardCount;i++){
-      const p = platforms[1 + Math.floor(rng()*(platforms.length-1))];
-      hazards.push({x: p.x + 10 + Math.floor(rng()*(p.w-30)), y: p.y-10, w: 24, h: 10});
+      const p = hazardPool[Math.floor(rng()*hazardPool.length)];
+      const span = p.w - 56;
+      const hx = span > 0 ? p.x + 16 + Math.floor(rng()*span) : p.x + p.w/2 - 14;
+      hazards.push({x: Math.round(hx), y: p.y - 10, w: 28, h: 10});
     }
 
-    return { platforms, exit, hazards, groundH };
+    return { platforms, exit, hazards, groundH, seed: baseSeed };
   }
 
   // Resolve vertical collision with platforms (very simple)

--- a/js/storage.js
+++ b/js/storage.js
@@ -9,6 +9,7 @@
     level: 1,
     coins: 0,           // "time shards"
     bestLevel: 1,
+    currentSeed: null,
     upgrades: {         // basic permanent shop upgrades
       speed: 0,
       jump: 0,


### PR DESCRIPTION
## Summary
- add persistent level seeds so new runs randomize layouts while continues keep their floor
- rebuild the level generator to create reachable exit platforms and safer hazard placement
- ensure deaths and floor transitions roll fresh layouts to prevent repeating impossible stages

## Testing
- Manual - Loaded game.html

------
https://chatgpt.com/codex/tasks/task_e_68e13812afd8832faa429c8614552fdd